### PR TITLE
Add Cloud Agent development environment for OctoFit Tracker

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,6 @@
+{
+  "name": "OctoFit Tracker",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "ports": [3000, 8000, 27017]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -39,12 +39,27 @@ install_mongodb() {
   echo "==> Installed $(mongod --version | head -n1)"
 }
 
+ensure_python_venv() {
+  # The base image ships python3 without the venv/ensurepip module, which the
+  # Django backend needs for its virtual environment.
+  if python3 -c "import ensurepip" >/dev/null 2>&1; then
+    return
+  fi
+  echo "==> Installing python3-venv / python3-pip"
+  local py_minor
+  py_minor="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+  sudo apt-get update
+  sudo apt-get install -y "python${py_minor}-venv" python3-pip
+}
+
 setup_backend() {
   local backend_dir="octofit-tracker/backend"
   if [ ! -f "${backend_dir}/requirements.txt" ]; then
     echo "==> Skipping backend setup (no ${backend_dir}/requirements.txt yet)"
     return
   fi
+
+  ensure_python_venv
 
   echo "==> Setting up Django backend virtual environment"
   if [ ! -d "${backend_dir}/venv" ]; then

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Idempotent environment bootstrap for the OctoFit Tracker course.
+#
+# Installs the toolchain the exercise depends on (MongoDB) and, when the
+# generated application already exists, refreshes its Python and Node
+# dependencies. The application itself is created by the learner during the
+# course, so every project-specific step is guarded to keep this script a
+# no-op on the bare template.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MONGODB_MAJOR="8.0"
+KEYRING="/usr/share/keyrings/mongodb-server-${MONGODB_MAJOR}.gpg"
+SOURCES_LIST="/etc/apt/sources.list.d/mongodb-org-${MONGODB_MAJOR}.list"
+
+install_mongodb() {
+  if command -v mongod >/dev/null 2>&1; then
+    echo "==> MongoDB already installed: $(mongod --version | head -n1)"
+    return
+  fi
+
+  echo "==> Installing MongoDB ${MONGODB_MAJOR} from the official repository"
+  # shellcheck disable=SC1091
+  . /etc/os-release
+
+  curl -fsSL "https://pgp.mongodb.com/server-${MONGODB_MAJOR}.asc" \
+    | sudo gpg --dearmor --yes -o "$KEYRING"
+
+  echo "deb [ arch=amd64,arm64 signed-by=${KEYRING} ] https://repo.mongodb.org/apt/ubuntu ${VERSION_CODENAME}/mongodb-org/${MONGODB_MAJOR} multiverse" \
+    | sudo tee "$SOURCES_LIST" >/dev/null
+
+  sudo apt-get update
+  sudo apt-get install -y mongodb-org
+
+  echo "==> Installed $(mongod --version | head -n1)"
+}
+
+setup_backend() {
+  local backend_dir="octofit-tracker/backend"
+  if [ ! -f "${backend_dir}/requirements.txt" ]; then
+    echo "==> Skipping backend setup (no ${backend_dir}/requirements.txt yet)"
+    return
+  fi
+
+  echo "==> Setting up Django backend virtual environment"
+  if [ ! -d "${backend_dir}/venv" ]; then
+    python3 -m venv "${backend_dir}/venv"
+  fi
+  "${backend_dir}/venv/bin/python" -m pip install --upgrade pip
+  "${backend_dir}/venv/bin/pip" install -r "${backend_dir}/requirements.txt"
+}
+
+setup_frontend() {
+  local frontend_dir="octofit-tracker/frontend"
+  if [ ! -f "${frontend_dir}/package.json" ]; then
+    echo "==> Skipping frontend setup (no ${frontend_dir}/package.json yet)"
+    return
+  fi
+
+  echo "==> Installing React frontend dependencies"
+  if [ -f "${frontend_dir}/package-lock.json" ]; then
+    (cd "${frontend_dir}" && npm ci)
+  else
+    (cd "${frontend_dir}" && npm install)
+  fi
+}
+
+install_mongodb
+setup_backend
+setup_frontend
+
+echo "==> Environment install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -2,44 +2,30 @@
 #
 # Per-boot startup for the OctoFit Tracker course.
 #
-# Brings up the MongoDB daemon that the Django backend connects to. The
-# script is idempotent: it does nothing if a server is already listening,
-# starts one otherwise, and waits until the database is ready before
-# returning so dependent services can rely on it.
+# Brings up the MongoDB daemon that the Django backend connects to. On boot
+# this command is launched detached and nothing waits on it, so MongoDB is
+# run in the foreground (non-daemonizing) and stays attached for the lifetime
+# of the environment. The script is idempotent: if a server is already
+# listening it exits immediately instead of starting a duplicate.
 
 set -euo pipefail
 
 DATA_DIR="${OCTOFIT_MONGO_DATA_DIR:-$HOME/.octofit/mongodb}"
-LOG_FILE="${OCTOFIT_MONGO_LOG:-$HOME/.octofit/mongod.log}"
 PORT="${OCTOFIT_MONGO_PORT:-27017}"
 
-mkdir -p "$DATA_DIR" "$(dirname "$LOG_FILE")"
+mkdir -p "$DATA_DIR"
 
 mongo_ready() {
   mongosh --quiet --port "$PORT" --eval 'db.runCommand({ ping: 1 }).ok' 2>/dev/null | grep -q '^1$'
 }
 
 if mongo_ready; then
-  echo "==> MongoDB already running on port ${PORT}"
+  echo "==> MongoDB already running on port ${PORT}; nothing to do"
   exit 0
 fi
 
-echo "==> Starting MongoDB on port ${PORT} (dbpath: ${DATA_DIR})"
-mongod \
-  --dbpath "$DATA_DIR" \
-  --bind_ip 127.0.0.1 \
-  --port "$PORT" \
-  --fork \
-  --logpath "$LOG_FILE"
+# A stale lock file from a previous, non-clean shutdown blocks startup.
+rm -f "${DATA_DIR}/mongod.lock" 2>/dev/null || true
 
-for _ in $(seq 1 30); do
-  if mongo_ready; then
-    echo "==> MongoDB is ready on port ${PORT}"
-    exit 0
-  fi
-  sleep 1
-done
-
-echo "!! MongoDB did not become ready within 30s; recent log:" >&2
-tail -n 20 "$LOG_FILE" >&2 || true
-exit 1
+echo "==> Starting MongoDB (foreground) on port ${PORT} (dbpath: ${DATA_DIR})"
+exec mongod --dbpath "$DATA_DIR" --bind_ip 127.0.0.1 --port "$PORT"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Per-boot startup for the OctoFit Tracker course.
+#
+# Brings up the MongoDB daemon that the Django backend connects to. The
+# script is idempotent: it does nothing if a server is already listening,
+# starts one otherwise, and waits until the database is ready before
+# returning so dependent services can rely on it.
+
+set -euo pipefail
+
+DATA_DIR="${OCTOFIT_MONGO_DATA_DIR:-$HOME/.octofit/mongodb}"
+LOG_FILE="${OCTOFIT_MONGO_LOG:-$HOME/.octofit/mongod.log}"
+PORT="${OCTOFIT_MONGO_PORT:-27017}"
+
+mkdir -p "$DATA_DIR" "$(dirname "$LOG_FILE")"
+
+mongo_ready() {
+  mongosh --quiet --port "$PORT" --eval 'db.runCommand({ ping: 1 }).ok' 2>/dev/null | grep -q '^1$'
+}
+
+if mongo_ready; then
+  echo "==> MongoDB already running on port ${PORT}"
+  exit 0
+fi
+
+echo "==> Starting MongoDB on port ${PORT} (dbpath: ${DATA_DIR})"
+mongod \
+  --dbpath "$DATA_DIR" \
+  --bind_ip 127.0.0.1 \
+  --port "$PORT" \
+  --fork \
+  --logpath "$LOG_FILE"
+
+for _ in $(seq 1 30); do
+  if mongo_ready; then
+    echo "==> MongoDB is ready on port ${PORT}"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "!! MongoDB did not become ready within 30s; recent log:" >&2
+tail -n 20 "$LOG_FILE" >&2 || true
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for this GitHub Skills course, which guides building the **OctoFit/monafit Tracker** full-stack app (Django REST backend + React frontend + MongoDB).

The default Cloud Agent image already provides Python 3.12 and Node 22, so the only missing piece is **MongoDB**. This PR adds a versioned, repository-managed environment (`.cursor/environment.json`), which is the highest-precedence config and automatically applies to future Cloud Agents once merged to `main`.

## What's included

- `.cursor/environment.json` — declares the `install`/`start` lifecycle and forwards ports `3000` (React), `8000` (Django), `27017` (MongoDB).
- `.cursor/install.sh` — idempotent bootstrap:
  - Installs MongoDB 8.0 from the official apt repository (only if not already present).
  - Ensures `python3-venv` is available (the base image ships Python without `ensurepip`).
  - **Guarded** project setup: creates the backend `venv` + `pip install` and runs frontend `npm install` only once the learner has generated `octofit-tracker/`. On the bare template it is a clean no-op.
- `.cursor/start.sh` — per-boot startup that launches MongoDB. It is idempotent (exits early if a server is already listening) and runs `mongod` in the foreground so the service persists when the start command is launched detached on boot.

## Validation

Validated on the VM and via draft environment builds booted from the default image:

| Check | Result |
| --- | --- |
| `install.sh` from scratch on default image (draft build) | MongoDB `v8.0.29` installed, exit 0 |
| `install.sh` idempotence | Second run is a clean no-op |
| `start.sh` brings up MongoDB | `mongosh ... ping` → `{ ok: 1 }` |
| Backend deps (`Django`, `djangorestframework`, `django-cors-headers`, `pymongo`) | Installed in venv |
| Frontend deps (React + Bootstrap via Vite) | `npm install` OK |
| End-to-end app: MongoDB → Django REST API → React UI | Seeded data rendered in the browser (see agent walkthrough video) |
| Fresh Cloud Agent (booted from tested build) | Python 3.12.3 / Node 22.14 / npm 10.9.7 / mongod 8.0.29 present; real Mongo insert+find OK |

Note: draft-build test agents do not execute the `start` phase on boot, so auto-start could only be verified by invoking `start.sh` directly (which succeeds). On real agent boots the platform launches `start` detached, which is the documented mechanism for bringing up databases.

## Notes

- The generated application code is intentionally **not** committed — it is what the course learner builds. This PR only provides the reproducible environment.
- Optional follow-up: enabling environment **builds** for this repo would bake the MongoDB install into a prebuilt snapshot so new agents skip the ~30s apt install on each boot.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6adcb3d3-adfe-4800-af6e-f92d5adfe845?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6adcb3d3-adfe-4800-af6e-f92d5adfe845&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

